### PR TITLE
support map

### DIFF
--- a/env.go
+++ b/env.go
@@ -3,6 +3,7 @@ package multiconfig
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -58,10 +59,12 @@ func (e *EnvironmentLoader) processField(prefix string, field *structs.Field, na
 	switch strctMap.(type) {
 	case map[string]interface{}:
 		for key, val := range strctMap.(map[string]interface{}) {
-			field := field.Field(key)
-
-			if err := e.processField(fieldName, field, key, val); err != nil {
-				return err
+			switch field.Kind() {
+			case reflect.Struct:
+				field := field.Field(key)
+				if err := e.processField(fieldName, field, key, val); err != nil {
+					return err
+				}
 			}
 		}
 	default:

--- a/multiconfig_test.go
+++ b/multiconfig_test.go
@@ -18,6 +18,15 @@ type (
 		unexported string
 		Interval   time.Duration
 		Threads    []Thread
+		Maps 		map[string]Request
+	}
+
+	Request struct {
+		Header Header
+	}
+
+	Header struct {
+		Context string
 	}
 
 	// Postgres holds Postgresql database related configuration

--- a/testdata/config.json
+++ b/testdata/config.json
@@ -20,5 +20,14 @@
       "192.168.2.3"
     ],
     "AvailabilityRatio": 8.23
+  },
+  "maps": {
+    "Default": {
+      "Request": {
+        "Header": {
+          "Context":"RequestValue"
+        }
+      }
+    }
   }
 }

--- a/testdata/config.toml
+++ b/testdata/config.toml
@@ -10,3 +10,6 @@ Enabled           = true
 Port              = 5432
 Hosts             = ["192.168.2.1", "192.168.2.2", "192.168.2.3"]
 AvailabilityRatio = 8.23
+
+[Maps.Default.Request.Header]
+Context = "RequestValue"

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -26,3 +26,9 @@ postgres:
         - 192.168.2.3
     availabilityratio:  8.23
 
+maps:
+  default:
+    request:
+      header:
+        context: RequestValue
+


### PR DESCRIPTION
if field type is map, multiconfig will panic.
now we can load config to map, but cantnot set by env variable.